### PR TITLE
Don't repeat Horizon prefix if it's present when inflating problems.

### DIFF
--- a/support/render/problem/main.go
+++ b/support/render/problem/main.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	"github.com/stellar/go/support/errors"
 	"github.com/stellar/go/support/log"
+	"strings"
 )
+
+const HorizonHost = "https://stellar.org/horizon-errors/"
 
 // P is a struct that represents an error response to be rendered to a connected
 // client.
@@ -44,8 +46,10 @@ func RegisterError(err error, p P) {
 func Inflate(p *P) {
 	//TODO: add requesting url to extra info
 
-	//TODO: make this prefix configurable
-	p.Type = "https://stellar.org/horizon-errors/" + p.Type
+	if !strings.HasPrefix(p.Type, HorizonHost) {
+		//TODO: make the HorizonHost prefix configurable
+		p.Type = HorizonHost + p.Type
+	}
 
 	p.Instance = ""
 }

--- a/support/render/problem/main_test.go
+++ b/support/render/problem/main_test.go
@@ -2,6 +2,7 @@ package problem
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http/httptest"
@@ -114,6 +115,27 @@ func TestServerErrorConversion(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestInflate test errors that come inflated from horizon
+func TestInflate(t *testing.T) {
+	kase := struct {
+		name     string
+		p        interface{}
+		want     string
+	}{
+		"renders the type correctly",
+		P{Type: "https://stellar.org/horizon-errors/not_found"},
+		"https://stellar.org/horizon-errors/not_found",
+	}
+
+	t.Run(kase.name, func(t *testing.T) {
+		w := testRender(context.Background(), kase.p)
+		var payload P
+		json.Unmarshal([]byte(w.Body.String()), &payload)
+
+		assert.Equal(t, kase.want, payload.Type)
+	})
 }
 
 func testRender(ctx context.Context, p interface{}) *httptest.ResponseRecorder {


### PR DESCRIPTION
There is an inconsistency in the `type` returned by `friendbot` when making
request which fail in `Horizon`. The following is an example taken from a
failed request (notice the prefix in type):

```
{

"type":"https://stellar.org/horizon-errors/https://stellar.org/horizon-errors/not_found",
 "title":"Resource Missing",
 "status":404,
 "detail":"The resource at the url requested was not found.  This is
 usually occurs for one of two reasons:  The url requested is not
 valid, or no data in our database could be found with the parameters
 provided."
}
```

The issue was on the `Inflate` method which is used across different
projects. Horizon was returning the type already "inflated" and then
`friendbot` was inflating it again, appending the prefix twice.