### PR TITLE
services/horizon: Ignore db.ErrCanceled and ctx.Canceled returned by verifyState

### DIFF
--- a/services/horizon/internal/expingest/processors/effects_processor.go
+++ b/services/horizon/internal/expingest/processors/effects_processor.go
@@ -457,10 +457,13 @@ func (operation *transactionOperationWrapper) setOptionsEffects() ([]effect, err
 				})
 				continue
 			}
-			effects.add(source.Address(), history.EffectSignerUpdated, map[string]interface{}{
-				"public_key": addy,
-				"weight":     weight,
-			})
+
+			if weight != before[addy] {
+				effects.add(source.Address(), history.EffectSignerUpdated, map[string]interface{}{
+					"public_key": addy,
+					"weight":     weight,
+				})
+			}
 		}
 
 		afterSortedSigners := []string{}

--- a/services/horizon/internal/expingest/processors/effects_processor_test.go
+++ b/services/horizon/internal/expingest/processors/effects_processor_test.go
@@ -1056,6 +1056,120 @@ func TestOperationEffectsSetOptionsSignersOrder(t *testing.T) {
 	tt.Equal(expected, effects)
 }
 
+// Regression for https://github.com/stellar/go/issues/2136
+func TestOperationEffectsSetOptionsSignersNoUpdated(t *testing.T) {
+	tt := assert.New(t)
+	transaction := io.LedgerTransaction{
+		Meta: createTransactionMeta([]xdr.OperationMeta{
+			xdr.OperationMeta{
+				Changes: []xdr.LedgerEntryChange{
+					// State
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryState,
+						State: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									Signers: []xdr.Signer{
+										xdr.Signer{
+											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+											Weight: 10,
+										},
+										xdr.Signer{
+											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+											Weight: 10,
+										},
+										xdr.Signer{
+											Key:    xdr.MustSigner("GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC"),
+											Weight: 17,
+										},
+									},
+								},
+							},
+						},
+					},
+					// Updated
+					xdr.LedgerEntryChange{
+						Type: xdr.LedgerEntryChangeTypeLedgerEntryUpdated,
+						Updated: &xdr.LedgerEntry{
+							Data: xdr.LedgerEntryData{
+								Type: xdr.LedgerEntryTypeAccount,
+								Account: &xdr.AccountEntry{
+									AccountId: xdr.MustAddress("GC3C4AKRBQLHOJ45U4XG35ESVWRDECWO5XLDGYADO6DPR3L7KIDVUMML"),
+									Signers: []xdr.Signer{
+										xdr.Signer{
+											Key:    xdr.MustSigner("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV"),
+											Weight: 16,
+										},
+										xdr.Signer{
+											Key:    xdr.MustSigner("GCAHY6JSXQFKWKP6R7U5JPXDVNV4DJWOWRFLY3Y6YPBF64QRL4BPFDNS"),
+											Weight: 10,
+										},
+										xdr.Signer{
+											Key:    xdr.MustSigner("GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE"),
+											Weight: 14,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}),
+	}
+	transaction.Index = 1
+	transaction.Envelope.Tx.SourceAccount = xdr.MustAddress("GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV")
+
+	operation := transactionOperationWrapper{
+		index:       0,
+		transaction: transaction,
+		operation: xdr.Operation{
+			Body: xdr.OperationBody{
+				Type:         xdr.OperationTypeSetOptions,
+				SetOptionsOp: &xdr.SetOptionsOp{},
+			},
+		},
+		ledgerSequence: 46,
+	}
+
+	effects, err := operation.effects()
+	tt.NoError(err)
+	expected := []effect{
+		effect{
+			address:     "GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+			operationID: int64(197568499713),
+			details: map[string]interface{}{
+				"public_key": "GA4O5DLUUTLCTMM2UOWOYPNIH2FTD4NLO6KDZOFQRUISQ3FYKABGJLPC",
+			},
+			effectType: history.EffectSignerRemoved,
+			order:      uint32(1),
+		},
+		effect{
+			address:     "GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+			operationID: int64(197568499713),
+			details: map[string]interface{}{
+				"public_key": "GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+				"weight":     int32(16),
+			},
+			effectType: history.EffectSignerUpdated,
+			order:      uint32(2),
+		},
+		effect{
+			address:     "GCBBDQLCTNASZJ3MTKAOYEOWRGSHDFAJVI7VPZUOP7KXNHYR3HP2BUKV",
+			operationID: int64(197568499713),
+			details: map[string]interface{}{
+				"public_key": "GCR3TQ2TVH3QRI7GQMC3IJGUUBR32YQHWBIKIMTYRQ2YH4XUTDB75UKE",
+				"weight":     int32(14),
+			},
+			effectType: history.EffectSignerCreated,
+			order:      uint32(3),
+		},
+	}
+	tt.Equal(expected, effects)
+}
+
 func TestOperationRegressionAccountTrustItself(t *testing.T) {
 	tt := assert.New(t)
 	// NOTE:  when an account trusts itself, the transaction is successful but


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `services/friendbot`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated any docs ([developer docs](https://www.stellar.org/developers/reference/), `.md`
  files, etc... affected by this change). Take a look in the `docs` folder for a given service,
  like [this one](https://github.com/stellar/go/tree/master/services/horizon/internal/docs).

### Release planning

* [ ] I've updated the relevant CHANGELOG ([here](services/horizon/CHANGELOG.md) for Horizon) if
  needed with deprecations, added features, breaking changes, and DB schema changes.
* [ ] I've decided if this PR requires a new major/minor version according to
  [semver](https://semver.org/), or if it's mainly a patch change. The PR is targeted at the next
  release branch if it's not a patch change.
</details>

### What

Ignore db.ErrCanceled and ctx.Canceled returned by verifyState.

Fix #2224

### Why

If the system is shutdown during state verification, there is a warning inthe log showing

``` WARN[2020-02-04T18:14:19.987+01:00] State verification errored
          err="addAccountsToStateVerifier failed: Error running
history.Q.GetAccountsByIDs: select failed: context canceled" pid=99452
service=expingest
```

If the system is being shutdown gracefully which is the case when we
get this errors, then we shouldn't log an error.

Fix #2224

### Known limitations

[TODO or N/A]